### PR TITLE
Add player-side board clicking to select ship placement coordinates.

### DIFF
--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -72,7 +72,7 @@
                 <button type="button" onclick="placeShip()">Place</button>
                 <BR><BR>
 
-                <p style="font-size:15px;margin: 3px;text-align: center">Select from the drop down menus above, or click your board to select ship placement coordinates. Then click "place".</p>
+                <p style="font-size:15px;margin: 3px;text-align: center">Select from the drop down menus above, or click your board to select placement coordinates. (If a ship won't place, check that the ship length doesn't go off the grid.)</p>
                 <p style="font-size:15px;margin: 3px;text-align: center">--------------</p>
                 <p style="font-size:15px;margin: 3px;text-align: center">Click on enemy board to Fire!</p>
                 <!--

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -70,9 +70,11 @@
                 </select>
                 <BR>
                 <button type="button" onclick="placeShip()">Place</button>
-                <BR><BR><BR>
+                <BR><BR>
 
-                <p style="font-size:20px;font-weight:bold;margin: 3px;text-align: center">Click to Fire!</p>
+                <p style="font-size:15px;margin: 3px;text-align: center">Select from the drop down menus above, or click your board to select ship placement coordinates. Then click "place".</p>
+                <p style="font-size:15px;margin: 3px;text-align: center">--------------</p>
+                <p style="font-size:15px;margin: 3px;text-align: center">Click on enemy board to Fire!</p>
                 <!--
                 Row:
                 <select name="rowFire" id="rowFire">

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -9,6 +9,13 @@ $( document ).ready(function() {
         gameModel = json;
     });
 
+    $('#MyBoard').on("click", "td", function (event) {
+        var coords = this.id.split("_");
+        $('#rowSelec').val(coords[0]);
+        $('#colSelec').val(coords[1]);
+    });
+
+
     $('#TheirBoard').on("click", "td", function (event) {
         var coords = this.id.split("_");
         fire(coords[0], coords[1]);
@@ -217,6 +224,20 @@ for (var i = 0; i < gameModel.playerHits.length; i++) {
          }
      }
  }
+
+    for (let ship of gameModel.playerShips) {
+        if (ship.type === "Ship" && ship.isSunk) {
+            for(i = 0; i < ship.length; i++){
+                if(ship.isVert == true){
+
+                    $( '#MyBoard #' + (ship.start.Down + i) + '_' + ship.start.Across ).css("background-color", "purple");
+                }
+                else{
+                    $( '#MyBoard #' + ship.start.Down + '_' + (ship.start.Across + i) ).css("background-color", "purple");
+                }
+            }
+        }
+    }
 }
 
 // Gets an individual tile's intended color (for the computer's board only)


### PR DESCRIPTION
This PR adds:
- Clicking on the player-side board to more quickly select placement coordinates.
- Matches player-side Civilian ship color when sunken, to bring it in line with the computer side.
- Simple HTML edit to further clarify the game instructions.